### PR TITLE
Rebuild landing page layout to mirror requested showcase

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,120 +1,325 @@
 <!DOCTYPE html>
 <html lang="fr">
-<!DOCTYPE html>
-<html lang="fr">
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>La Délicieuserie</title>
+    <meta name="description" content="Site vitrine moderne et responsive inspiré du cabinet de diététique de Louann Cousseau." />
+    <title>Site vitrine - Modèle professionnel</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700&family=Source+Sans+3:wght@300;400;600;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-    <!-- En-tête / navigation -->
-    <header>
-        <nav>
-            <h1 class="logo">La Délicieuserie</h1>
-            <ul class="nav-links">
-                <li><a href="#accueil">Accueil</a></li>
-                <li><a href="#produits">Les biscuits</a></li>
-                <li><a href="#apropos">À propos</a></li>
-                <li><a href="#contact">Contact</a></li>
-            </ul>
-            <!-- Icône “burger” pour mobile -->
-            <div class="burger" id="burger">
-                <div></div>
-                <div></div>
-                <div></div>
+    <a class="skip-link" href="#main">Aller au contenu principal</a>
+
+    <header class="site-header" id="accueil">
+        <div class="top-banner">
+            <div class="container">
+                <p>Consultations en présentiel &amp; en ligne • Rendez-vous du lundi au samedi</p>
+                <div class="top-banner__cta">
+                    <a href="tel:+33600000000" class="top-link">06 00 00 00 00</a>
+                    <a href="#contact" class="top-link">Prendre rendez-vous</a>
+                </div>
             </div>
-        </nav>
+        </div>
+        <div class="container">
+            <div class="navbar" role="navigation" aria-label="Navigation principale">
+                <a class="brand" href="#accueil">
+                    <img src="assets/logo.png" alt="Logo du cabinet" />
+                    <span>
+                        <strong>Louann Cousseau</strong>
+                        <small>Diététicienne - Nutritionniste</small>
+                    </span>
+                </a>
+                <button class="nav-toggle" aria-expanded="false" aria-controls="primary-menu">
+                    <span class="sr-only">Ouvrir le menu</span>
+                    <span></span>
+                    <span></span>
+                    <span></span>
+                </button>
+                <nav id="primary-menu" class="nav-links">
+                    <a href="#accueil">Accueil</a>
+                    <a href="#approche">Approche</a>
+                    <a href="#services">Accompagnements</a>
+                    <a href="#consultations">Consultations</a>
+                    <a href="#temoignages">Avis</a>
+                    <a href="#contact">Contact</a>
+                </nav>
+            </div>
+        </div>
+        <div class="hero" role="presentation">
+            <div class="container hero__content">
+                <p class="hero__subtitle">Retrouvez un équilibre durable</p>
+                <h1 class="hero__title">Une approche nutritionnelle <br />bienveillante &amp; personnalisée</h1>
+                <p class="hero__text">
+                    Je vous accompagne pas à pas vers des habitudes alimentaires sereines, adaptées à votre rythme de vie et à vos objectifs.
+                </p>
+                <div class="hero__actions">
+                    <a class="btn btn--primary" href="#contact">Prendre rendez-vous</a>
+                    <a class="btn btn--ghost" href="#services">Découvrir mes accompagnements</a>
+                </div>
+            </div>
+        </div>
     </header>
 
-    
+    <main id="main">
+        <section class="highlights" aria-labelledby="highlights-title">
+            <div class="container">
+                <h2 id="highlights-title" class="section-title">Pourquoi choisir cet accompagnement&nbsp;?</h2>
+                <div class="highlight-grid">
+                    <article class="highlight-card">
+                        <div class="highlight-icon" aria-hidden="true">🍽️</div>
+                        <h3>Approche intuitive</h3>
+                        <p>On oublie les régimes restrictifs. L’objectif est de retrouver une relation apaisée à l’alimentation et à son corps.</p>
+                    </article>
+                    <article class="highlight-card">
+                        <div class="highlight-icon" aria-hidden="true">🤝</div>
+                        <h3>Accompagnement humain</h3>
+                        <p>Chaque séance est pensée comme un moment d’écoute et d’échanges pour construire un suivi à votre image.</p>
+                    </article>
+                    <article class="highlight-card">
+                        <div class="highlight-icon" aria-hidden="true">🎯</div>
+                        <h3>Objectifs durables</h3>
+                        <p>Des outils concrets et personnalisés pour ancrer de nouvelles habitudes et gagner en bien-être au quotidien.</p>
+                    </article>
+                </div>
+            </div>
+        </section>
 
+        <section class="about" id="apropos" aria-labelledby="about-title">
+            <div class="container about__wrapper">
+                <div class="about__image" role="presentation">
+                    <img src="images/produit2.jpg" alt="Portrait ou illustration" />
+                </div>
+                <div class="about__content">
+                    <h2 id="about-title" class="section-title">Louann Cousseau</h2>
+                    <p class="section-subtitle">Diététicienne-Nutritionniste diplômée &amp; passionnée</p>
+                    <p>
+                        J’accompagne adultes, adolescents et enfants pour retrouver une alimentation sereine, sans culpabilité. Mon approche repose sur l’écoute active, la pédagogie et le respect de votre rythme.
+                    </p>
+                    <p>
+                        Qu’il s’agisse de troubles digestifs, de rééquilibrage alimentaire ou d’un accompagnement lié à une pathologie, nous avançons ensemble, pas à pas.
+                    </p>
+                    <ul class="about__list">
+                        <li>Consultations en cabinet et en visio</li>
+                        <li>Plans alimentaires personnalisés</li>
+                        <li>Suivi régulier et ressources à chaque étape</li>
+                    </ul>
+                    <a class="btn btn--primary" href="#contact">Échanger ensemble</a>
+                </div>
+            </div>
+        </section>
 
-    <section id="accueil" class="hero">
-        <div class="hero-content">
-            <h2>Bienvenue chez <span>La Délicieuserie</span></h2>
-            <p>Des produits artisanaux uniques et savoureux.</p>
-            <a href="#produits" class="btn">Voir nos biscuits</a>
+        <section class="approach" id="approche" aria-labelledby="approach-title">
+            <div class="container">
+                <div class="section-intro">
+                    <h2 id="approach-title" class="section-title">Mon approche</h2>
+                    <p class="section-subtitle">Un parcours en trois temps pour construire un équilibre qui vous ressemble</p>
+                </div>
+                <div class="steps">
+                    <article class="step">
+                        <span class="step__number">01</span>
+                        <h3>Comprendre votre histoire</h3>
+                        <p>Un temps d’échange pour cerner vos habitudes, vos objectifs et vos contraintes afin de poser les bases du suivi.</p>
+                    </article>
+                    <article class="step">
+                        <span class="step__number">02</span>
+                        <h3>Co-construire votre plan</h3>
+                        <p>Des conseils concrets, des outils et des recettes adaptés à votre quotidien pour avancer à votre rythme.</p>
+                    </article>
+                    <article class="step">
+                        <span class="step__number">03</span>
+                        <h3>Suivre &amp; ajuster</h3>
+                        <p>Des rendez-vous réguliers pour mesurer vos progrès, lever les freins et ancrer durablement les nouvelles habitudes.</p>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="services" id="services" aria-labelledby="services-title">
+            <div class="container">
+                <div class="section-intro">
+                    <h2 id="services-title" class="section-title">Accompagnements proposés</h2>
+                    <p class="section-subtitle">Des consultations adaptées à vos besoins personnels et professionnels</p>
+                </div>
+                <div class="service-grid">
+                    <article class="service-card">
+                        <img src="images/produit1.jpg" alt="Rééquilibrage alimentaire" />
+                        <div class="service-card__content">
+                            <h3>Rééquilibrage alimentaire</h3>
+                            <p>Identifier vos besoins, construire une alimentation variée, plaisir et santé réunis.</p>
+                            <ul>
+                                <li>Bilans complets</li>
+                                <li>Plans et recettes personnalisés</li>
+                                <li>Suivi motivationnel</li>
+                            </ul>
+                        </div>
+                    </article>
+                    <article class="service-card">
+                        <img src="images/produit3.jpg" alt="Pathologies et troubles digestifs" />
+                        <div class="service-card__content">
+                            <h3>Pathologies &amp; troubles digestifs</h3>
+                            <p>Adapter votre alimentation en cas de diabète, hypercholestérolémie, MICI, intolérances…</p>
+                            <ul>
+                                <li>Collaboration avec votre médecin</li>
+                                <li>Supports pédagogiques</li>
+                                <li>Suivi régulier</li>
+                            </ul>
+                        </div>
+                    </article>
+                    <article class="service-card">
+                        <img src="images/produit4.jpg" alt="Nutrition du sportif" />
+                        <div class="service-card__content">
+                            <h3>Nutrition du sportif</h3>
+                            <p>Optimiser vos performances, favoriser la récupération et prévenir les blessures.</p>
+                            <ul>
+                                <li>Programme individualisé</li>
+                                <li>Stratégies autour des entraînements</li>
+                                <li>Suivi de la composition corporelle</li>
+                            </ul>
+                        </div>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="consultations" id="consultations" aria-labelledby="consultations-title">
+            <div class="container consultations__wrapper">
+                <div class="consultations__content">
+                    <h2 id="consultations-title" class="section-title">Déroulé des consultations</h2>
+                    <p class="section-subtitle">Des rendez-vous structurés pour avancer en toute sérénité</p>
+                    <div class="timeline">
+                        <article class="timeline__item">
+                            <h3>1. Bilan initial – 1h</h3>
+                            <p>Analyse complète de votre mode de vie, de vos habitudes alimentaires et de vos objectifs.</p>
+                        </article>
+                        <article class="timeline__item">
+                            <h3>2. Plan d’action personnalisé</h3>
+                            <p>Remise d’outils pratiques, fiches conseils, idées menus et astuces pour gérer le quotidien.</p>
+                        </article>
+                        <article class="timeline__item">
+                            <h3>3. Séances de suivi – 30 min</h3>
+                            <p>Évaluation des progrès, ajustements, motivation et réponses à toutes vos questions.</p>
+                        </article>
+                    </div>
+                    <a class="btn btn--ghost" href="#contact">Demander les tarifs</a>
+                </div>
+                <div class="consultations__image" role="presentation">
+                    <img src="hero.jpg" alt="Salle de consultation" />
+                </div>
+            </div>
+        </section>
+
+        <section class="testimonials" id="temoignages" aria-labelledby="testimonials-title">
+            <div class="container">
+                <div class="section-intro">
+                    <h2 id="testimonials-title" class="section-title">Elles &amp; ils en parlent</h2>
+                    <p class="section-subtitle">Des témoignages authentiques de personnes accompagnées</p>
+                </div>
+                <div class="testimonials__slider" role="region" aria-live="polite">
+                    <button class="slider__control" data-direction="prev" aria-label="Témoignage précédent">&#10094;</button>
+                    <div class="slider__track">
+                        <figure class="testimonial">
+                            <blockquote>
+                                «&nbsp;Louann m’a aidée à retrouver confiance et plaisir dans mon alimentation. Les résultats sont là et sans frustration&nbsp;!&nbsp;»
+                            </blockquote>
+                            <figcaption>Élodie – Programme bien-être</figcaption>
+                        </figure>
+                        <figure class="testimonial">
+                            <blockquote>
+                                «&nbsp;Un accompagnement très professionnel et humain. Chaque séance est motivante et rassurante.&nbsp;»
+                            </blockquote>
+                            <figcaption>Marc – Suivi nutritionnel sportif</figcaption>
+                        </figure>
+                        <figure class="testimonial">
+                            <blockquote>
+                                «&nbsp;Grâce aux outils donnés par Louann, j’ai trouvé un équilibre durable malgré mes contraintes familiales.&nbsp;»
+                            </blockquote>
+                            <figcaption>Sarah – Rééquilibrage alimentaire</figcaption>
+                        </figure>
+                    </div>
+                    <button class="slider__control" data-direction="next" aria-label="Témoignage suivant">&#10095;</button>
+                </div>
+            </div>
+        </section>
+
+        <section class="cta" aria-labelledby="cta-title">
+            <div class="container cta__wrapper">
+                <div>
+                    <h2 id="cta-title">Prêt·e à démarrer&nbsp;?</h2>
+                    <p>Réservez votre rendez-vous découverte de 15 minutes offert pour faire le point sur vos besoins.</p>
+                </div>
+                <a class="btn btn--primary" href="mailto:contact@exemple.fr">Contact direct</a>
+            </div>
+        </section>
+
+        <section class="contact" id="contact" aria-labelledby="contact-title">
+            <div class="container contact__grid">
+                <div>
+                    <h2 id="contact-title" class="section-title">Contact &amp; informations pratiques</h2>
+                    <p class="section-subtitle">Cabinet situé au 12 rue des Cerisiers, 62000 Arras</p>
+                    <ul class="contact__list">
+                        <li>
+                            <span class="contact__icon" aria-hidden="true">📞</span>
+                            <a href="tel:+33600000000">06 00 00 00 00</a>
+                        </li>
+                        <li>
+                            <span class="contact__icon" aria-hidden="true">✉️</span>
+                            <a href="mailto:contact@exemple.fr">contact@exemple.fr</a>
+                        </li>
+                        <li>
+                            <span class="contact__icon" aria-hidden="true">📍</span>
+                            <span>12 rue des Cerisiers, 62000 Arras</span>
+                        </li>
+                    </ul>
+                    <p class="contact__info">
+                        Accès en bus ligne B (arrêt République) – Stationnement gratuit à proximité.
+                    </p>
+                </div>
+                <form class="contact__form">
+                    <div class="form-group">
+                        <label for="name">Nom complet</label>
+                        <input id="name" name="name" type="text" placeholder="Votre nom" required />
+                    </div>
+                    <div class="form-group">
+                        <label for="email">Adresse e-mail</label>
+                        <input id="email" name="email" type="email" placeholder="vous@exemple.fr" required />
+                    </div>
+                    <div class="form-group">
+                        <label for="phone">Téléphone</label>
+                        <input id="phone" name="phone" type="tel" placeholder="06 00 00 00 00" />
+                    </div>
+                    <div class="form-group">
+                        <label for="message">Message</label>
+                        <textarea id="message" name="message" rows="4" placeholder="Parlez-moi de votre projet"></textarea>
+                    </div>
+                    <button class="btn btn--primary" type="submit">Envoyer le message</button>
+                    <p class="form-disclaimer">En soumettant ce formulaire, vous acceptez d’être recontacté·e par e-mail.</p>
+                </form>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <div class="container footer__grid">
+            <div>
+                <strong>Louann Cousseau</strong>
+                <p>Diététicienne - Nutritionniste</p>
+                <p>Numéro ADELI&nbsp;: 000000000</p>
+            </div>
+            <div>
+                <p>&copy; <span id="current-year"></span> Tous droits réservés.</p>
+                <a href="#">Mentions légales</a>
+            </div>
+            <div class="footer__socials">
+                <a href="#" aria-label="Instagram">Instagram</a>
+                <a href="#" aria-label="Facebook">Facebook</a>
+                <a href="#" aria-label="LinkedIn">LinkedIn</a>
+            </div>
         </div>
-    </section>
-
-    <section id="produits" class="produits">
-        <h2>Nos Produits</h2>
-        <div class="grid-produits">
-            <div class="card-produit">
-                <img src="images/produit1.jpg" alt="Produit 1" />
-                <h3>Sablé</h3>
-                <p>Sablé artisanal personnalisable.</p>
-                <a href="#" class="btn btn-small">Détails</a>
-            </div>
-            <div class="card-produit">
-                <img src="images/produit2.jpg" alt="Produit 2" />
-                <h3>Sablé</h3>
-                <p>Sablé artisanal personnalisable.</p>
-                <a href="#" class="btn btn-small">Détails</a>
-            </div>
-            <div class="card-produit">
-                <img src="images/produit3.jpg" alt="Produit 3" />
-                <h3>Sablé</h3>
-                <p>Sablé artisanal personnalisable.</p>
-                <a href="#" class="btn btn-small">Détails</a>
-            </div>
-            <div class="card-produit">
-                <img src="images/produit4.jpg" alt="Produit 4" />
-                <h3>sablé</h3>
-                <p>Sablé artisanal personnalisable.</p>
-                <a href="#" class="btn btn-small">Détails</a>
-            </div> 
-            -- Dupliquez ce bloc pour chaque produit -->
-        </div>
-    </section>
-
-    <section id="apropos" class="apropos">
-  <h2>À propos</h2>
-  
-  <p>✨ <strong>La Délicieuserie – Biscuiterie artisanale et personnalisée à Calais</strong> ✨</p>
-  
-  <p>Bienvenue à <strong>La Délicieuserie</strong>, une biscuiterie artisanale à taille humaine, installée au cœur de Calais.<br>
-  Ici, chaque sablé est pensé comme une petite attention unique, fabriqué avec soin et passion.</p>
-  
-  <p>Nous travaillons exclusivement avec des <strong>matières premières issues de l’agriculture biologique</strong>, 
-  pour vous garantir des biscuits savoureux, authentiques et respectueux de l’environnement.</p>
-  
-  <p>Notre spécialité ? Le <strong>sablé 100% personnalisable</strong>.  
-  Que vous soyez particulier ou entreprise, nous donnons vie à vos envies :</p>
-  
-  <ul>
-    <li>choix de la <strong>forme</strong> et de la <strong>taille</strong>,</li>
-    <li>ajout d’un <strong>prénom</strong>, d’un <strong>message</strong> ou d’une <strong>date</strong>,</li>
-    <li>intégration d’un <strong>dessin</strong>, d’un <strong>logo</strong> ou d’un motif unique.</li>
-  </ul>
-  
-  <p>Chaque biscuit devient ainsi un support gourmand pour transmettre vos émotions, marquer un événement ou valoriser votre image.</p>
-  
-  <p>Que ce soit pour un <strong>mariage</strong>, une <strong>naissance</strong>, un <strong>anniversaire</strong>, 
-  ou encore pour des <strong>cadeaux d’entreprise</strong> et événements professionnels, 
-  nous vous accompagnons pour créer des douceurs qui reflètent parfaitement votre univers.</p>
-  
-  <p>Parce qu’ici, rien n’est industriel : chaque sablé est façonné à la main, 
-  dans une démarche <strong>locale, humaine et artisanale</strong>, où la gourmandise rencontre la créativité.</p>
-</section>
-
-
-    <section id="contact" class="contact">
-        <h2>Contact</h2>
-        <form>
-            <label>Nom :<input type="text" name="nom" required /></label>
-            <label>Email :<input type="email" name="email" required /></label>
-            <label>Message :<textarea name="message" rows="4"></textarea></label>
-            <button type="submit" class="btn">Envoyer</button>
-        </form>
-    </section>
-
-    <footer>
-        <p>© 2024 La Délicieuserie. Tous droits réservés.</p>
     </footer>
 
-    <script src="script.js"></script>
+    <script src="script.js" defer></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,133 @@
-const burger = document.getElementById('burger');
-const navLinks = document.querySelector('.nav-links');
+document.addEventListener('DOMContentLoaded', () => {
+    const navToggle = document.querySelector('.nav-toggle');
+    const navLinks = document.querySelector('.nav-links');
+    const navAnchors = navLinks ? Array.from(navLinks.querySelectorAll('a')) : [];
 
-burger.addEventListener('click', () => {
-    navLinks.classList.toggle('nav-active');
+    const closeMenu = () => {
+        if (!navToggle || !navLinks) {
+            return;
+        }
+        navLinks.classList.remove('open');
+        navToggle.setAttribute('aria-expanded', 'false');
+    };
+
+    if (navToggle && navLinks) {
+        navToggle.addEventListener('click', () => {
+            const isOpen = navLinks.classList.toggle('open');
+            navToggle.setAttribute('aria-expanded', String(isOpen));
+        });
+
+        navAnchors.forEach((anchor) => {
+            anchor.addEventListener('click', () => {
+                if (window.innerWidth <= 960) {
+                    closeMenu();
+                }
+            });
+        });
+
+        window.addEventListener('resize', () => {
+            if (window.innerWidth > 960) {
+                navLinks.classList.remove('open');
+                navToggle.setAttribute('aria-expanded', 'false');
+            }
+        });
+    }
+
+    const yearSpan = document.getElementById('current-year');
+    if (yearSpan) {
+        yearSpan.textContent = new Date().getFullYear().toString();
+    }
+
+    const track = document.querySelector('.slider__track');
+    const slides = track ? Array.from(track.querySelectorAll('.testimonial')) : [];
+    const prevBtn = document.querySelector('[data-direction="prev"]');
+    const nextBtn = document.querySelector('[data-direction="next"]');
+    let currentIndex = 0;
+    let autoplayId;
+
+    const isDesktop = () => window.innerWidth > 960;
+
+    const updateSlider = () => {
+        if (!track || slides.length === 0) {
+            return;
+        }
+
+        const slide = slides[0];
+        const slideStyle = window.getComputedStyle(slide);
+        const slideWidth = slide.offsetWidth;
+        const gap = parseFloat(slideStyle.marginRight || '0');
+        const offset = (slideWidth + gap) * currentIndex;
+        track.style.transform = `translateX(-${offset}px)`;
+    };
+
+    const goToSlide = (index) => {
+        if (slides.length === 0) {
+            return;
+        }
+
+        const lastIndex = slides.length - 1;
+        if (index < 0) {
+            currentIndex = lastIndex;
+        } else if (index > lastIndex) {
+            currentIndex = 0;
+        } else {
+            currentIndex = index;
+        }
+        updateSlider();
+    };
+
+    const startAutoplay = () => {
+        if (!isDesktop() || slides.length <= 1) {
+            stopAutoplay();
+            return;
+        }
+        stopAutoplay();
+        autoplayId = window.setInterval(() => {
+            goToSlide(currentIndex + 1);
+        }, 6000);
+    };
+
+    const stopAutoplay = () => {
+        if (autoplayId) {
+            window.clearInterval(autoplayId);
+            autoplayId = undefined;
+        }
+    };
+
+    if (prevBtn && nextBtn && slides.length > 1) {
+        prevBtn.addEventListener('click', () => {
+            if (!isDesktop()) return;
+            goToSlide(currentIndex - 1);
+        });
+
+        nextBtn.addEventListener('click', () => {
+            if (!isDesktop()) return;
+            goToSlide(currentIndex + 1);
+        });
+
+        if (track) {
+            track.addEventListener('mouseenter', stopAutoplay);
+            track.addEventListener('mouseleave', startAutoplay);
+        }
+        prevBtn.addEventListener('mouseenter', stopAutoplay);
+        nextBtn.addEventListener('mouseenter', stopAutoplay);
+        prevBtn.addEventListener('mouseleave', startAutoplay);
+        nextBtn.addEventListener('mouseleave', startAutoplay);
+
+        window.addEventListener('resize', () => {
+            if (!isDesktop()) {
+                stopAutoplay();
+                currentIndex = 0;
+                if (track) {
+                    track.style.transform = 'translateX(0)';
+                }
+            } else {
+                updateSlider();
+                startAutoplay();
+            }
+        });
+
+        updateSlider();
+        startAutoplay();
+    }
 });

--- a/styles.css
+++ b/styles.css
@@ -1,200 +1,863 @@
-/* Styles de base */
-body {
+:root {
+    --font-heading: "Playfair Display", serif;
+    --font-body: "Source Sans 3", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    --color-primary: #6b7a62;
+    --color-primary-dark: #4c5a45;
+    --color-accent: #e7b997;
+    --color-background: #f8f6f1;
+    --color-surface: #ffffff;
+    --color-text: #2e2c2a;
+    --color-muted: #6f6b67;
+    --shadow-soft: 0 24px 60px rgba(27, 33, 20, 0.12);
+    --radius-lg: 24px;
+    --radius-md: 16px;
+    --radius-sm: 10px;
+    --container-width: min(1120px, 92vw);
+    --transition: 0.3s ease;
+}
+
+* {
+    box-sizing: border-box;
     margin: 0;
-    font-family: sans-serif;
-    color: #333;
+    padding: 0;
 }
-h1, h2, h3 {
-    font-family: 'Montserrat', sans-serif;
+
+html {
+    scroll-behavior: smooth;
 }
+
+body {
+    font-family: var(--font-body);
+    font-size: 17px;
+    line-height: 1.7;
+    color: var(--color-text);
+    background: var(--color-background);
+    -webkit-font-smoothing: antialiased;
+}
+
 a {
-    text-decoration: none;
     color: inherit;
+    text-decoration: none;
+}
+
+a:hover,
+a:focus {
+    color: var(--color-primary-dark);
+}
+
+img {
+    max-width: 100%;
+    display: block;
+}
+
+.container {
+    width: var(--container-width);
+    margin: 0 auto;
+}
+
+.section-title {
+    font-family: var(--font-heading);
+    font-size: clamp(2rem, 3vw, 2.6rem);
+    color: var(--color-primary-dark);
+    margin-bottom: 0.75rem;
+}
+
+.section-subtitle {
+    color: var(--color-muted);
+    font-size: 1rem;
+    margin-bottom: 2rem;
+}
+
+.section-intro {
+    text-align: center;
+    margin-bottom: 3rem;
+    max-width: 680px;
+    margin-inline: auto;
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    border-radius: 999px;
+    padding: 0.85rem 1.8rem;
+    transition: transform var(--transition), box-shadow var(--transition);
+    text-align: center;
+    white-space: nowrap;
+}
+
+.btn--primary {
+    background: var(--color-primary);
+    color: #fff;
+    box-shadow: 0 18px 32px rgba(75, 92, 69, 0.24);
+}
+
+.btn--primary:hover,
+.btn--primary:focus {
+    transform: translateY(-2px);
+    box-shadow: 0 26px 40px rgba(75, 92, 69, 0.28);
+}
+
+.btn--ghost {
+    border: 1px solid rgba(107, 122, 98, 0.35);
+    color: var(--color-primary-dark);
+    background: transparent;
+}
+
+.btn--ghost:hover,
+.btn--ghost:focus {
+    border-color: var(--color-primary-dark);
+    transform: translateY(-2px);
+}
+
+.skip-link {
+    position: absolute;
+    top: -40px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #000;
+    color: #fff;
+    padding: 0.75rem 1.5rem;
+    border-radius: 999px;
+    transition: top 0.2s ease;
+    z-index: 1000;
+}
+
+.skip-link:focus {
+    top: 16px;
+}
+
+/* Top banner */
+.top-banner {
+    background: var(--color-primary);
+    color: #fff;
+    font-size: 0.95rem;
+    padding: 0.6rem 0;
+}
+
+.top-banner .container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.top-banner__cta {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.top-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-weight: 600;
+    color: #fff;
+}
+
+.top-link::after {
+    content: "→";
+    font-size: 0.85em;
+    transition: transform var(--transition);
+}
+
+.top-link:hover::after,
+.top-link:focus::after {
+    transform: translateX(4px);
 }
 
 /* Navigation */
-nav {
+.site-header {
+    background: linear-gradient(180deg, rgba(248, 246, 241, 0.85) 0%, rgba(248, 246, 241, 0.97) 100%);
+    position: relative;
+}
+
+.navbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.3rem 0;
+    position: relative;
+    gap: 1.5rem;
+}
+
+.brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.85rem;
+    color: var(--color-primary-dark);
+}
+
+.brand img {
+    width: 58px;
+    height: 58px;
+    object-fit: contain;
+}
+
+.brand strong {
+    display: block;
+    font-family: var(--font-heading);
+    font-size: 1.35rem;
+    letter-spacing: 0.04em;
+}
+
+.brand small {
+    font-size: 0.85rem;
+    color: var(--color-muted);
+}
+
+.nav-links {
+    display: flex;
+    align-items: center;
+    gap: 1.8rem;
+    font-weight: 600;
+    color: var(--color-muted);
+}
+
+.nav-links a {
+    position: relative;
+    padding-bottom: 0.2rem;
+}
+
+.nav-links a::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    height: 2px;
+    background: var(--color-primary);
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform var(--transition);
+}
+
+.nav-links a:hover::after,
+.nav-links a:focus::after {
+    transform: scaleX(1);
+}
+
+.nav-toggle {
+    display: none;
+    flex-direction: column;
+    justify-content: center;
+    gap: 5px;
+    width: 48px;
+    height: 48px;
+    border: 1px solid rgba(107, 122, 98, 0.35);
+    border-radius: 50%;
+    background: transparent;
+    cursor: pointer;
+    transition: background var(--transition);
+}
+
+.nav-toggle span {
+    display: block;
+    width: 22px;
+    height: 2px;
+    background: var(--color-primary-dark);
+    margin: 0 auto;
+    border-radius: 999px;
+}
+
+.nav-toggle:hover,
+.nav-toggle:focus {
+    background: rgba(107, 122, 98, 0.08);
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+}
+
+/* Hero */
+.hero {
+    position: relative;
+    isolation: isolate;
+    background: linear-gradient(rgba(55, 66, 52, 0.45), rgba(55, 66, 52, 0.55)), url("hero.jpg") center/cover no-repeat;
+    border-radius: var(--radius-lg);
+    margin-bottom: 3.5rem;
+}
+
+.hero::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 20% 20%, rgba(231, 185, 151, 0.2) 0%, transparent 55%);
+    z-index: -1;
+}
+
+.hero__content {
+    padding: clamp(3rem, 8vw, 5.5rem) clamp(2rem, 6vw, 4.5rem);
+    color: #fff;
+    max-width: 640px;
+}
+
+.hero__subtitle {
+    letter-spacing: 0.3em;
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    margin-bottom: 1rem;
+}
+
+.hero__title {
+    font-family: var(--font-heading);
+    font-size: clamp(2.8rem, 5vw, 3.6rem);
+    line-height: 1.1;
+    margin-bottom: 1.4rem;
+}
+
+.hero__text {
+    font-size: 1.05rem;
+    margin-bottom: 2rem;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.hero__actions {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+/* Highlights */
+.highlights {
+    padding: 4rem 0 2rem;
+}
+
+.highlight-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.5rem;
+}
+
+.highlight-card {
+    background: var(--color-surface);
+    border-radius: var(--radius-md);
+    padding: 2rem;
+    box-shadow: 0 18px 40px rgba(78, 89, 67, 0.08);
+    transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.highlight-card:hover,
+.highlight-card:focus-within {
+    transform: translateY(-6px);
+    box-shadow: 0 24px 52px rgba(78, 89, 67, 0.12);
+}
+
+.highlight-card h3 {
+    font-family: var(--font-heading);
+    margin-bottom: 0.8rem;
+    color: var(--color-primary-dark);
+}
+
+.highlight-card p {
+    color: var(--color-muted);
+}
+
+.highlight-icon {
+    font-size: 1.8rem;
+    margin-bottom: 1rem;
+}
+
+/* About */
+.about {
+    padding: 5rem 0;
+}
+
+.about__wrapper {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr);
+    gap: 3.5rem;
+    align-items: center;
+}
+
+.about__image {
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    box-shadow: var(--shadow-soft);
+    transform: rotate(-1.5deg);
+}
+
+.about__image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.about__content p + p {
+    margin-top: 1.25rem;
+}
+
+.about__list {
+    margin: 2rem 0;
+    list-style: none;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.about__list li::before {
+    content: "✔";
+    color: var(--color-primary);
+    margin-right: 0.7rem;
+}
+
+/* Approach */
+.approach {
+    padding: 5rem 0;
+    background: linear-gradient(135deg, rgba(235, 224, 204, 0.6), rgba(248, 246, 241, 0.4));
+}
+
+.steps {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.8rem;
+}
+
+.step {
+    background: var(--color-surface);
+    padding: 2.2rem 1.8rem;
+    border-radius: var(--radius-md);
+    position: relative;
+    overflow: hidden;
+    box-shadow: 0 18px 44px rgba(52, 65, 48, 0.12);
+}
+
+.step__number {
+    position: absolute;
+    top: 1.5rem;
+    right: 1.5rem;
+    font-size: 3.6rem;
+    font-family: var(--font-heading);
+    color: rgba(107, 122, 98, 0.1);
+}
+
+.step h3 {
+    font-family: var(--font-heading);
+    margin-bottom: 0.9rem;
+    color: var(--color-primary-dark);
+}
+
+.step p {
+    color: var(--color-muted);
+}
+
+/* Services */
+.services {
+    padding: 5.5rem 0;
+}
+
+.service-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 2rem;
+}
+
+.service-card {
+    background: var(--color-surface);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    box-shadow: var(--shadow-soft);
+    display: flex;
+    flex-direction: column;
+}
+
+.service-card img {
+    height: 220px;
+    object-fit: cover;
+    width: 100%;
+}
+
+.service-card__content {
+    padding: 2.2rem 2rem 2.4rem;
+}
+
+.service-card__content h3 {
+    font-family: var(--font-heading);
+    margin-bottom: 0.85rem;
+    color: var(--color-primary-dark);
+}
+
+.service-card__content ul {
+    margin-top: 1.4rem;
+    list-style: none;
+    display: grid;
+    gap: 0.6rem;
+}
+
+.service-card__content li::before {
+    content: "•";
+    color: var(--color-accent);
+    margin-right: 0.5rem;
+}
+
+/* Consultations */
+.consultations {
+    padding: 5rem 0;
+}
+
+.consultations__wrapper {
+    display: grid;
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+    gap: 3rem;
+    align-items: center;
+}
+
+.consultations__image {
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    box-shadow: var(--shadow-soft);
+}
+
+.consultations__image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.timeline {
+    display: grid;
+    gap: 1.5rem;
+    margin: 2rem 0 2.5rem;
+}
+
+.timeline__item {
+    background: rgba(107, 122, 98, 0.08);
+    border-radius: var(--radius-md);
+    padding: 1.6rem 1.8rem;
+}
+
+.timeline__item h3 {
+    font-family: var(--font-heading);
+    margin-bottom: 0.6rem;
+}
+
+/* Testimonials */
+.testimonials {
+    padding: 5.5rem 0;
+    background: linear-gradient(135deg, rgba(107, 122, 98, 0.08), rgba(231, 185, 151, 0.15));
+}
+
+.testimonials__slider {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 1.5rem;
+}
+
+.slider__track {
+    display: flex;
+    transition: transform 0.5s ease;
+    scroll-behavior: smooth;
+}
+
+.testimonial {
+    background: var(--color-surface);
+    border-radius: var(--radius-lg);
+    padding: 2.4rem 2.2rem;
+    margin-right: 1.5rem;
+    min-width: clamp(260px, 80vw, 520px);
+    box-shadow: var(--shadow-soft);
+}
+
+.testimonial blockquote {
+    font-style: italic;
+    color: var(--color-text);
+    margin-bottom: 1.4rem;
+}
+
+.testimonial figcaption {
+    font-weight: 600;
+    color: var(--color-primary-dark);
+}
+
+.slider__control {
+    background: var(--color-primary);
+    color: #fff;
+    border: none;
+    width: 46px;
+    height: 46px;
+    border-radius: 50%;
+    cursor: pointer;
+    display: grid;
+    place-items: center;
+    font-size: 1.6rem;
+    transition: transform var(--transition), background var(--transition);
+}
+
+.slider__control:hover,
+.slider__control:focus {
+    background: var(--color-primary-dark);
+    transform: scale(1.05);
+}
+
+/* CTA */
+.cta {
+    padding: 4.5rem 0;
+}
+
+.cta__wrapper {
+    background: linear-gradient(135deg, var(--color-primary) 0%, #8aa282 100%);
+    color: #fff;
+    padding: clamp(2.5rem, 6vw, 3.5rem);
+    border-radius: var(--radius-lg);
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 1rem 2rem;
-    background: #fff;
-    box-shadow: 0 1px 6px rgba(0,0,0,0.1);
-}
-.nav-links {
-    display: flex;
-    list-style: none;
-    gap: 2rem;
-}
-.burger {
-    display: none;
-    flex-direction: column;
-    cursor: pointer;
-}
-.burger div {
-    width: 25px;
-    height: 3px;
-    background-color: #333;
-    margin: 4px;
+    gap: 2.5rem;
+    flex-wrap: wrap;
+    box-shadow: var(--shadow-soft);
 }
 
-/* Section hero */
-.hero {
-    position: relative;
-    background: url('images/hero.jpg') center/cover no-repeat;
-    height: 80vh;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    text-align: center;
-    color: #fff;
-}
-.hero-content {
-    background: rgba(0,0,0,0.5);
-    padding: 2rem;
-    border-radius: 10px;
-}
-.hero .btn {
-    margin-top: 1rem;
+.cta__wrapper h2 {
+    font-family: var(--font-heading);
+    font-size: clamp(2.2rem, 3.2vw, 2.8rem);
+    margin-bottom: 0.7rem;
 }
 
-/* Section produits */
-.produits {
-    padding: 3rem 2rem;
+.cta__wrapper p {
+    color: rgba(255, 255, 255, 0.88);
+    max-width: 460px;
 }
-.grid-produits {
+
+/* Contact */
+.contact {
+    padding: 5rem 0 6rem;
+}
+
+.contact__grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 2rem;
-}
-.card-produit {
-    border: 1px solid #ddd;
-    border-radius: 8px;
-    overflow: hidden;
-    text-align: center;
-}
-.card-produit img {
-    width: 100%;
-    height: 200px;
-    object-fit: cover;
-}
-.btn {
-    display: inline-block;
-    padding: 0.7rem 1.2rem;
-    background: #b452cd;
-    color: #fff;
-    border: none;
-    border-radius: 4px;
-}
-.btn-small {
-    padding: 0.4rem 0.8rem;
-    font-size: 0.9rem;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 3rem;
+    align-items: start;
 }
 
-/* Sections à propos et contact */
-.apropos, .contact {
-    padding: 2rem;
+.contact__list {
+    list-style: none;
+    display: grid;
+    gap: 1rem;
+    margin-bottom: 2rem;
 }
-form {
+
+.contact__list li {
     display: flex;
-    flex-direction: column;
-    max-width: 400px;
+    align-items: center;
 }
-form label {
-    margin-bottom: 1rem;
+
+.contact__list a {
+    font-weight: 600;
 }
-form input, form textarea {
-    padding: 0.5rem;
-    border: 1px solid #ccc;
+
+.contact__icon {
+    width: 2.4rem;
+    height: 2.4rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: rgba(107, 122, 98, 0.12);
+    margin-right: 0.75rem;
+    font-size: 1.1rem;
+}
+
+.contact__info {
+    color: var(--color-muted);
+}
+
+.contact__form {
+    background: var(--color-surface);
+    border-radius: var(--radius-lg);
+    padding: 2.5rem 2.2rem;
+    box-shadow: var(--shadow-soft);
+    display: grid;
+    gap: 1.5rem;
+}
+
+.form-group {
+    display: grid;
+    gap: 0.5rem;
+}
+
+.form-group label {
+    font-weight: 600;
+    color: var(--color-primary-dark);
+}
+
+.form-group input,
+.form-group textarea {
+    padding: 0.85rem 1rem;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(107, 122, 98, 0.25);
+    font: inherit;
+    transition: border var(--transition), box-shadow var(--transition);
+    background: #fff;
+}
+
+.form-group input:focus,
+.form-group textarea:focus {
+    outline: none;
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px rgba(107, 122, 98, 0.18);
+}
+
+.form-group textarea {
+    resize: vertical;
+}
+
+.form-disclaimer {
+    font-size: 0.85rem;
+    color: var(--color-muted);
 }
 
 /* Footer */
-footer {
-    text-align: center;
-    padding: 1rem;
-    background: #f8f8f8;
+.site-footer {
+    background: #22211f;
+    color: rgba(255, 255, 255, 0.82);
+    padding: 2.5rem 0;
+}
+
+.footer__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 2rem;
+    align-items: center;
+}
+
+.footer__grid a {
+    color: rgba(255, 255, 255, 0.82);
+    font-weight: 600;
+}
+
+.footer__grid a:hover,
+.footer__grid a:focus {
+    color: var(--color-accent);
+}
+
+.footer__socials {
+    display: flex;
+    gap: 1rem;
 }
 
 /* Responsive */
-@media (max-width: 768px) {
+@media (max-width: 960px) {
+    .nav-toggle {
+        display: flex;
+    }
+
     .nav-links {
-        display: none;
-        flex-direction: column;
-        gap: 1rem;
         position: absolute;
-        top: 60px;
-        right: 20px;
-        background: white;
-        padding: 1rem;
-        box-shadow: 0 1px 6px rgba(0,0,0,0.2);
+        top: calc(100% + 12px);
+        right: 0;
+        background: var(--color-surface);
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1.2rem;
+        padding: 1.6rem 1.8rem;
+        border-radius: var(--radius-md);
+        box-shadow: var(--shadow-soft);
+        transform: scale(0.95);
+        transform-origin: top right;
+        opacity: 0;
+        visibility: hidden;
+        transition: var(--transition);
+        min-width: 240px;
+        z-index: 10;
     }
-    .burger {
-        display: flex;
+
+    .nav-links.open {
+        opacity: 1;
+        visibility: visible;
+        transform: scale(1);
     }
-    .nav-active {
-        display: flex;
+
+    .navbar {
+        align-items: center;
+    }
+
+    .hero {
+        border-radius: 20px;
+    }
+
+    .about__wrapper,
+    .consultations__wrapper {
+        grid-template-columns: 1fr;
+    }
+
+    .about__image,
+    .consultations__image {
+        order: -1;
+    }
+
+    .testimonials__slider {
+        grid-template-columns: 1fr;
+    }
+
+    .slider__control {
+        display: none;
+    }
+
+    .slider__track {
+        overflow-x: auto;
+        scroll-snap-type: x mandatory;
+    }
+
+    .testimonial {
+        scroll-snap-align: start;
+        margin-right: 1rem;
+        min-width: min(80vw, 420px);
     }
 }
-/* ===== Header avec image de fond (safe merge) ===== */
 
-/* (Optionnel) variables si tu veux changer facilement d'image */
-:root{
-  --header-bg-desktop: url("images/fond-biscuits.jpg");
-  --header-bg-mobile:  url("images/fond-biscuits-mobile.jpg");
+@media (max-width: 640px) {
+    body {
+        font-size: 16px;
+    }
+
+    .top-banner .container {
+        justify-content: center;
+        text-align: center;
+    }
+
+    .hero__content {
+        padding: 3rem 1.8rem;
+    }
+
+    .hero__actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .highlight-card,
+    .service-card__content,
+    .contact__form {
+        padding: 1.8rem;
+    }
+
+    .cta__wrapper {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .footer__socials {
+        justify-content: flex-start;
+    }
 }
 
-header{
-  position: relative;
-  color: #fff;
-  min-height: 280px;
-  display: flex;
-  align-items: center;
-  /* Image de fond */
-  background-image: var(--header-bg-desktop);
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
-  /* On supprime l’éventuel espace blanc */
-  margin: 0;
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
 }
-
-/* Voile pour la lisibilité du texte */
-header::before{
-  content:"";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(to bottom, rgba(0,0,0,.45), rgba(0,0,0,.25));
-  z-index: 0;
-}
-
-/* On garde ton layout de nav, mais on change l’arrière-plan SEULEMENT dans le header */
-header nav{
-  background: rgba(0,0,0,.35);   /* remplace le blanc du nav dans le header */
-  box-shadow: none;               /* évite l’ombre sur l’image */
-  border-radius: 12px;
-  width: 100%;
-  max-width: 1200px;
-  margin: 16px auto;
-  position: relative;
-  z-index: 1;                     /* au-dessus du voile */
-}
-
-/* Lisibilité du logo et des liens dans le header */
-header .logo{ color: #fff; }
-header .nav-links a{ color: #fff; }
-
-/* Menu mobile (on respecte ta logique .nav-active existante) */
-@media (max-width: 768px){
-  header{
-    background-image: var(--header-bg-mobile), var(--header-bg-desktop);
-    background-position: center 30%;
-    min-height: 220px;
-  }
-  /* Le dropdown mobile quand nav a .nav-active */
-  header .nav-links{
-    background: rgba(0,0,0,.8);  /* foncé pour contraste sur l’image */
-    color: #fff;
-  }
-  header .nav-links a{ color: #fff; }
-}
-


### PR DESCRIPTION
## Summary
- rebuild the landing page structure with hero, highlights, services, testimonials and contact sections
- replace the stylesheet with a refined responsive design using new typography, palette and layout rules
- enhance the JavaScript to support the mobile navigation toggle and a testimonial slider with autoplay

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68c9593358848320b106bf1d63d79f5b